### PR TITLE
feat: Add examples page to docs

### DIFF
--- a/docs/pages/examples.js
+++ b/docs/pages/examples.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import examples from '../../examples/examples';
+import Layout from '../utils/layout';
+import { withStyles } from 'tss-react/mui';
+
+const styles = theme => ({
+  root: {
+    padding: theme.spacing(3),
+  },
+  exampleContainer: {
+    marginBottom: theme.spacing(4),
+  },
+});
+
+class ExamplesPage extends React.Component {
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <Layout>
+        <div className={classes.root}>
+          <h1>Examples</h1>
+          {Object.entries(examples).map(([name, Component]) => (
+            <div key={name} className={classes.exampleContainer}>
+              <h2>{name}</h2>
+              <Component />
+            </div>
+          ))}
+        </div>
+      </Layout>
+    );
+  }
+}
+
+export default withStyles(ExamplesPage, styles);

--- a/docs/utils/Menu.js
+++ b/docs/utils/Menu.js
@@ -6,6 +6,7 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import ListSubheader from '@mui/material/ListSubheader';
+import Link from 'next/link';
 
 const styles = theme => ({
   list: {
@@ -50,6 +51,11 @@ class Menu extends React.Component {
                 Examples
               </ListSubheader>
             }>
+            <Link href="/examples">
+              <ListItem button>
+                <ListItemText primary="All Examples" />
+              </ListItem>
+            </Link>
             {sandboxes.map(item => (
               <SandboxItem href={item.href} name={item.name} />
             ))}


### PR DESCRIPTION
This commit adds a new page to the documentation site that displays all the examples from the `examples` directory.

- Creates a new page at `docs/pages/examples.js` to render the examples.
- Adds a link to the new examples page in the main navigation menu.