### PR TITLE
fix(buildColumns): filter out-of-range columnOrder indices to prevent crash

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -618,7 +618,11 @@ class MUIDataTable extends React.Component {
     });
 
     if (Array.isArray(newColumnOrder)) {
-      columnOrder = newColumnOrder;
+      // Filter out any stale indices that exceed the current column count. This can happen when
+      // a persisted columnOrder (e.g. from localStorage) was saved with more columns than the
+      // current column definitions contain. Without this guard, columns[staleIndex] returns
+      // undefined and any downstream access (e.g. column.display) throws a TypeError.
+      columnOrder = newColumnOrder.filter(idx => Number.isInteger(idx) && idx >= 0 && idx < columnData.length);
     } else if (
       Array.isArray(prevColumnOrder) &&
       Array.isArray(newColumns) &&


### PR DESCRIPTION
## Problem

When a consumer passes a `columnOrder` option that was persisted from a previous session and the column definitions have since changed (column added or removed), `buildColumns` assigns the stale array directly:

```js
if (Array.isArray(newColumnOrder)) {
  columnOrder = newColumnOrder;  // no bounds check
}
```

Any index in `newColumnOrder` that is `>= columnData.length` causes `columns[staleIndex]` to return `undefined` in `TableHead.js`:

```js
let orderedColumns = columnOrder.map((colIndex, idx) => ({
  column: columns[colIndex],  // undefined if staleIndex >= columns.length
  ...
}));
```

Downstream reads of `column.display` then throw `TypeError: Cannot read properties of undefined (reading 'display')`, which triggers a full React error boundary and a broken page for the user.

This is the root cause of a production crash reported at [huvrdata/huvr#12916](https://github.com/huvrdata/huvr/issues/12916).

## Fix

Filter the incoming `columnOrder` to only valid indices before accepting it:

```js
columnOrder = newColumnOrder.filter(
  idx => Number.isInteger(idx) && idx >= 0 && idx < columnData.length
);
```

MUI DataTables handles a shorter-than-full-length `columnOrder` gracefully — it appends unordered columns at the end. Users with a stale order self-heal on next load with no data loss.

## Testing

- Pass a `columnOrder` with an out-of-range index (e.g. `[0, 1, 99]` for a 3-column table) — table should render without crashing, with column 99 silently dropped
- Normal column dragging and reordering still works as expected